### PR TITLE
Add version number as part of cli name

### DIFF
--- a/.github/workflows/odfe-cli-publish-artifacts.yml
+++ b/.github/workflows/odfe-cli-publish-artifacts.yml
@@ -8,6 +8,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      - name: Get Version
+        run: |
+          TAG_NAME=${GITHUB_REF#refs/*/}
+          echo "RELEASE_VERSION=${TAG_NAME:1}" >> $GITHUB_ENV
+
       - name: Set up Go ubuntu-latest
         uses: actions/setup-go@v2
         with:
@@ -27,29 +32,29 @@ jobs:
       - name: Upload macOS(amd64) Artifact
         uses: actions/upload-artifact@v2
         with:
-          name: odfe-cli-macOS-amd64
+          name: odfe-cli-${{ env.RELEASE_VERSION }}-macOS-amd64
           path: dist/odfe-cli_darwin_amd64/odfe-cli
 
       - name: Upload Linux(amd64) Artifact
         uses: actions/upload-artifact@v2
         with:
-          name: odfe-cli-linux-amd64
+          name: odfe-cli-${{ env.RELEASE_VERSION }}-linux-amd64
           path: dist/odfe-cli_linux_amd64/odfe-cli
 
       - name: Upload Linux(arm64) Artifact
         uses: actions/upload-artifact@v2
         with:
-          name: odfe-cli-linux-arm64
+          name: odfe-cli-${{ env.RELEASE_VERSION }}-linux-arm64
           path: dist/odfe-cli_linux_arm64/odfe-cli
 
       - name: Upload Windows(i386) Artifact
         uses: actions/upload-artifact@v2
         with:
-          name: odfe-cli-windows-386
+          name: odfe-cli-${{ env.RELEASE_VERSION }}-windows-386
           path: dist/odfe-cli_windows_386/odfe-cli.exe
 
       - name: Upload Windows(amd64) Artifact
         uses: actions/upload-artifact@v2
         with:
-          name: odfe-cli-windows-amd64
+          name: odfe-cli-${{ env.RELEASE_VERSION }}-windows-amd64
           path: dist/odfe-cli_windows_amd64/odfe-cli.exe


### PR DESCRIPTION
The artifacts name will look like "odfe-cli-a.b.c-windows-amd64"  when tag va.b.c is created.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
