### PR TITLE
Move profile flag to base command

### DIFF
--- a/commands/ad.go
+++ b/commands/ad.go
@@ -16,7 +16,6 @@
 package commands
 
 import (
-	"fmt"
 	"odfe-cli/client"
 	adctrl "odfe-cli/controller/ad"
 	esctrl "odfe-cli/controller/es"
@@ -29,8 +28,7 @@ import (
 )
 
 const (
-	adCommandName   = "ad"
-	flagProfileName = "profile"
+	adCommandName = "ad"
 )
 
 //adCommand is base command for Anomaly Detection plugin.
@@ -41,7 +39,6 @@ var adCommand = &cobra.Command{
 }
 
 func init() {
-	adCommand.Flags().StringP(flagProfileName, "p", "", "Use a specific profile from your configuration file")
 	adCommand.Flags().BoolP("help", "h", false, "Help for Anomaly Detection")
 	GetRoot().AddCommand(adCommand)
 }
@@ -58,23 +55,12 @@ func GetADHandler() (*handler.Handler, error) {
 	if err != nil {
 		return nil, err
 	}
-	p, err := GetProfileController()
+	profile, err := GetProfile()
 	if err != nil {
 		return nil, err
 	}
-	profileFlagValue, err := GetADCommand().Flags().GetString(flagProfileName)
-	if err != nil {
-		return nil, err
-	}
-	profile, ok, err := p.GetProfileForExecution(profileFlagValue)
-	if err != nil {
-		return nil, err
-	}
-	if !ok {
-		return nil, fmt.Errorf("No profile found for execution. Try %s %s --help for more information.", RootCommandName, ProfileCommandName)
-	}
-	g := adgateway.New(c, &profile)
-	esg := esgateway.New(c, &profile)
+	g := adgateway.New(c, profile)
+	esg := esgateway.New(c, profile)
 	esc := esctrl.New(esg)
 	ctr := adctrl.New(os.Stdin, esc, g)
 	return handler.New(ctr), nil

--- a/commands/ad_create.go
+++ b/commands/ad_create.go
@@ -58,7 +58,6 @@ func generateTemplate() {
 
 func init() {
 	GetADCommand().AddCommand(createCmd)
-	createCmd.Flags().StringP(flagProfileName, "p", "", "Use a specific profile from your configuration file")
 	createCmd.Flags().BoolP(generate, "g", false, "Output sample detector configuration")
 	createCmd.Flags().BoolP("help", "h", false, "Help for "+createDetectorsCommandName)
 

--- a/commands/ad_delete.go
+++ b/commands/ad_delete.go
@@ -56,7 +56,6 @@ func init() {
 	GetADCommand().AddCommand(deleteDetectorsCmd)
 	deleteDetectorsCmd.Flags().BoolP(detectorForceDeletionFlagName, "f", false, "Delete the detector even if it is running")
 	deleteDetectorsCmd.Flags().BoolP(deleteDetectorIDFlagName, "", false, "Input is detector ID")
-	deleteDetectorsCmd.Flags().StringP(flagProfileName, "p", "", "Use a specific profile from your configuration file")
 	deleteDetectorsCmd.Flags().BoolP("help", "h", false, "Help for "+deleteDetectorsCommandName)
 }
 

--- a/commands/ad_get.go
+++ b/commands/ad_get.go
@@ -129,6 +129,5 @@ func Println(cmd *cobra.Command, d *entity.DetectorOutput) error {
 func init() {
 	GetADCommand().AddCommand(getDetectorsCmd)
 	getDetectorsCmd.Flags().BoolP(getDetectorIDFlagName, "", false, "Input is detector ID")
-	getDetectorsCmd.Flags().StringP(flagProfileName, "p", "", "Use a specific profile from your configuration file")
 	getDetectorsCmd.Flags().BoolP("help", "h", false, "Help for "+getDetectorsCommandName)
 }

--- a/commands/ad_start_stop.go
+++ b/commands/ad_start_stop.go
@@ -77,11 +77,9 @@ var stopDetectorsCmd = &cobra.Command{
 
 func init() {
 	startDetectorsCmd.Flags().BoolP(idFlagName, "", false, "Input is detector ID")
-	startDetectorsCmd.Flags().StringP(flagProfileName, "p", "", "Use a specific profile from your configuration file")
 	startDetectorsCmd.Flags().BoolP("help", "h", false, "Help for "+startDetectorsCommandName)
 	GetADCommand().AddCommand(startDetectorsCmd)
 	stopDetectorsCmd.Flags().BoolP(idFlagName, "", false, "Input is detector ID")
-	stopDetectorsCmd.Flags().StringP(flagProfileName, "p", "", "Use a specific profile from your configuration file")
 	stopDetectorsCmd.Flags().BoolP("help", "h", false, "Help for "+stopDetectorsCommandName)
 	GetADCommand().AddCommand(stopDetectorsCmd)
 }

--- a/commands/ad_update.go
+++ b/commands/ad_update.go
@@ -56,7 +56,6 @@ func init() {
 	GetADCommand().AddCommand(updateDetectorsCmd)
 	updateDetectorsCmd.Flags().BoolP(forceFlagName, "f", false, "Stop detector and update forcefully")
 	updateDetectorsCmd.Flags().BoolP(startFlagName, "s", false, "Start detector if update is successful")
-	updateDetectorsCmd.Flags().StringP(flagProfileName, "p", "", "Use a specific profile from your configuration file")
 	updateDetectorsCmd.Flags().BoolP("help", "h", false, "Help for "+updateDetectorsCommandName)
 }
 

--- a/commands/testdata/config.yaml
+++ b/commands/testdata/config.yaml
@@ -1,0 +1,9 @@
+profiles:
+  - name: test
+    endpoint: https://localhost:9200
+    user: admin
+    password: admin
+  - name: default
+    endpoint: http://localhost:9200
+    user: default
+    password: admin


### PR DESCRIPTION
Since, profile feature will be common to all plugins,
move profile as persistent flag to odfe-cli.
This will help other plugins to use value instead of
declaring it exclusively.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
