### PR TITLE
Allow non-secured cluster to be added to profile

### DIFF
--- a/commands/profile.go
+++ b/commands/profile.go
@@ -158,8 +158,8 @@ func CreateProfile(profileController profile.Controller, getNewProfile func(map[
 // getNewProfile gets new profile information from user using command line
 func getNewProfile(profileMap map[string]entity.Profile) entity.Profile {
 	var name string
-	fmt.Printf("Enter profile's name: ")
 	for {
+		fmt.Printf("Enter profile's name: ")
 		name = getUserInputAsText(checkInputIsNotEmpty)
 		if _, ok := profileMap[name]; !ok {
 			break
@@ -168,15 +168,33 @@ func getNewProfile(profileMap map[string]entity.Profile) entity.Profile {
 	}
 	fmt.Printf("Elasticsearch Endpoint: ")
 	endpoint := getUserInputAsText(checkInputIsNotEmpty)
-	fmt.Printf("User Name: ")
-	user := getUserInputAsText(checkInputIsNotEmpty)
-	fmt.Printf("Password: ")
-	password := getUserInputAsMaskedText(checkInputIsNotEmpty)
+	fmt.Printf("Is security plugin enabled? Y/N ")
+	isSecured := getUserInputAsBoolean(checkInputIsNotEmpty)
+	var user, password string
+	if isSecured {
+		fmt.Printf("User Name: ")
+		user = getUserInputAsText(checkInputIsNotEmpty)
+		fmt.Printf("Password: ")
+		password = getUserInputAsMaskedText(checkInputIsNotEmpty)
+	}
 	return entity.Profile{
 		Name:     name,
 		Endpoint: endpoint,
 		UserName: user,
 		Password: password,
+	}
+}
+
+func getUserInputAsBoolean(isValid func(input string) bool) bool {
+	response := getUserInputAsText(isValid)
+	switch strings.ToLower(response) {
+	case "y", "yes":
+		return true
+	case "n", "no":
+		return false
+	default:
+		fmt.Printf("please type (y)es or (n)o: ")
+		return getUserInputAsBoolean(isValid)
 	}
 }
 
@@ -194,7 +212,7 @@ func getUserInputAsText(isValid func(string) bool) string {
 // checkInputIsNotEmpty checks whether input is empty or not
 func checkInputIsNotEmpty(input string) bool {
 	if len(input) < 1 {
-		fmt.Print("value cannot be empty. Please enter non-empty value")
+		fmt.Print("Value cannot be empty, please enter non-empty value: ")
 		return false
 	}
 	return true

--- a/commands/profile_test.go
+++ b/commands/profile_test.go
@@ -39,6 +39,15 @@ func fakeInputProfile(map[string]entity.Profile) entity.Profile {
 	}
 }
 
+func fakeInSecuredInputProfile(map[string]entity.Profile) entity.Profile {
+	return entity.Profile{
+		Name:     "default",
+		Endpoint: "https://localhost:9200",
+		UserName: "",
+		Password: "",
+	}
+}
+
 func TestCreateProfile(t *testing.T) {
 	t.Run("create profile successfully", func(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
@@ -47,6 +56,15 @@ func TestCreateProfile(t *testing.T) {
 		mockProfileCtrl.EXPECT().GetProfilesMap().Return(nil, nil)
 		mockProfileCtrl.EXPECT().CreateProfile(fakeInputProfile(nil)).Return(nil)
 		err := CreateProfile(mockProfileCtrl, fakeInputProfile)
+		assert.NoError(t, err)
+	})
+	t.Run("create in-secured profile successfully", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+		mockProfileCtrl := mocks.NewMockController(mockCtrl)
+		mockProfileCtrl.EXPECT().GetProfilesMap().Return(nil, nil)
+		mockProfileCtrl.EXPECT().CreateProfile(fakeInSecuredInputProfile(nil)).Return(nil)
+		err := CreateProfile(mockProfileCtrl, fakeInSecuredInputProfile)
 		assert.NoError(t, err)
 	})
 	t.Run("create profile failed", func(t *testing.T) {

--- a/gateway/ad/ad_test.go
+++ b/gateway/ad/ad_test.go
@@ -331,16 +331,6 @@ func TestGateway_UpdateDetector(t *testing.T) {
 		err := testGateway.UpdateDetector(ctx, "id", nil)
 		assert.EqualError(t, err, "connection failed")
 	})
-	t.Run("invalid user", func(t *testing.T) {
-		testClient := getTestClient(t, `connection failed`, 400, http.MethodPut, "")
-		testGateway := New(testClient, &entity.Profile{
-			Endpoint: "http://localhost:9200",
-			UserName: "",
-			Password: "",
-		})
-		err := testGateway.UpdateDetector(ctx, "id", nil)
-		assert.EqualError(t, err, "user name and password cannot be empty")
-	})
 	t.Run("update success", func(t *testing.T) {
 		testClient := getTestClient(t, "ok", 200, http.MethodPut, "")
 		testGateway := New(testClient, &entity.Profile{

--- a/gateway/es/es_test.go
+++ b/gateway/es/es_test.go
@@ -83,15 +83,4 @@ func TestGateway_SearchDistinctValues(t *testing.T) {
 		_, err := testGateway.SearchDistinctValues(ctx, "test_index", "day_of_week")
 		assert.EqualError(t, err, "No connection found")
 	})
-	t.Run("search failed due to bad user config", func(t *testing.T) {
-
-		testClient := getTestClient(t, "No connection found", 400)
-		testGateway := New(testClient, &entity.Profile{
-			Endpoint: "http://localhost:9200",
-			UserName: "",
-			Password: "admin",
-		})
-		_, err := testGateway.SearchDistinctValues(ctx, "test_index", "day_of_week")
-		assert.EqualError(t, err, "user name and password cannot be empty")
-	})
 }

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -79,10 +79,9 @@ func (g *HTTPGateway) BuildRequest(ctx context.Context, method string, payload i
 		return nil, err
 	}
 	req := r.WithContext(ctx)
-	if len(g.Profile.UserName) == 0 || len(g.Profile.Password) == 0 {
-		return nil, fmt.Errorf("user name and password cannot be empty")
+	if len(g.Profile.UserName) != 0 {
+		req.SetBasicAuth(g.Profile.UserName, g.Profile.Password)
 	}
-	req.SetBasicAuth(g.Profile.UserName, g.Profile.Password)
 	if len(headers) == 0 {
 		return req, nil
 	}

--- a/gateway/knn/knn_test.go
+++ b/gateway/knn/knn_test.go
@@ -95,17 +95,6 @@ func TestGatewayGetStatistics(t *testing.T) {
 		assert.NoError(t, err)
 		assert.EqualValues(t, string(actual), "success")
 	})
-	t.Run("gateway failed due to bad user config", func(t *testing.T) {
-
-		testClient := getTestClient(t, "http://localhost:9200/_opendistro/_knn/stats", 400, []byte("failed"))
-		testGateway := New(testClient, &entity.Profile{
-			Endpoint: "http://localhost:9200",
-			UserName: "",
-			Password: "admin",
-		})
-		_, err := testGateway.GetStatistics(ctx, "", "")
-		assert.EqualError(t, err, "user name and password cannot be empty")
-	})
 	t.Run("gateway failed due to gateway user config", func(t *testing.T) {
 
 		testClient := getTestClient(t, "http://localhost:9200/_opendistro/_knn/stats", 400, []byte("failed"))
@@ -154,17 +143,6 @@ func TestGatewayWarmupIndices(t *testing.T) {
 		actual, err := testGateway.WarmupIndices(ctx, "index1,index2")
 		assert.NoError(t, err)
 		assert.EqualValues(t, string(actual), "success")
-	})
-	t.Run("failed due to bad user config", func(t *testing.T) {
-
-		testClient := getTestClient(t, "http://localhost:9200/_opendistro/_knn/warmup/index1", 400, []byte("failed"))
-		testGateway := New(testClient, &entity.Profile{
-			Endpoint: "http://localhost:9200",
-			UserName: "",
-			Password: "admin",
-		})
-		_, err := testGateway.WarmupIndices(ctx, "index1")
-		assert.EqualError(t, err, "user name and password cannot be empty")
 	})
 	t.Run("failed due to invalid index", func(t *testing.T) {
 


### PR DESCRIPTION
Since odfe users can create cluster by disabling security plugin,
make user name and password prompts configurable.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
