### PR TITLE
remove odfe-cli

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ bin
 .dockerfile-*
 
 /coverage.out
+
+odfe-cli
+odfe-cli.exe


### PR DESCRIPTION
update .gitignore to exclude odfe-cli binary


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
