### PR TITLE
Support AWS IAM Authentication

### DIFF
--- a/commands/profile.go
+++ b/commands/profile.go
@@ -16,6 +16,7 @@
 package commands
 
 import (
+	"errors"
 	"fmt"
 
 	"golang.org/x/term"
@@ -38,6 +39,10 @@ const (
 	ProfileCommandName          = "profile"
 	padding                     = 3
 	alignLeft                   = 0
+	FlagProfileCreateName       = "name"
+	FlagProfileCreateEndpoint   = "endpoint"
+	FlagProfileCreateAuthType   = "auth-type"
+	FlagProfileHelp             = "help"
 )
 
 //GetProfileController gets controller based on config file
@@ -64,19 +69,49 @@ var profileCommand = &cobra.Command{
 var createProfileCmd = &cobra.Command{
 	Use:   CreateNewProfileCommandName,
 	Short: "Create profile",
-	Long:  "Create profile with following fields: name, endpoint, user and password",
+	Long:  "Create named profile to save settings and credentials that you can apply to an odfe-cli command.",
 	Run: func(cmd *cobra.Command, args []string) {
 		profileController, err := GetProfileController()
 		if err != nil {
 			DisplayError(err, CreateNewProfileCommandName)
 			return
 		}
-		err = CreateProfile(profileController, getNewProfile)
+		name, err := getProfileName(cmd, profileController)
 		if err != nil {
 			DisplayError(err, CreateNewProfileCommandName)
 			return
 		}
+		endpoint, _ := cmd.Flags().GetString(FlagProfileCreateEndpoint)
+		newProfile := entity.Profile{
+			Name:     name,
+			Endpoint: endpoint,
+		}
+		switch authType, _ := cmd.Flags().GetString(FlagProfileCreateAuthType); authType {
+		case "disabled":
+			break
+		case "basic":
+			getBasicAuthDetails(&newProfile)
+		case "aws-iam":
+			getAWSIAMAuthDetails(&newProfile)
+		default:
+			DisplayError(errors.New("invalid value for auth-type. Use --help -h command to see permitted values"), CreateNewProfileCommandName)
+			return
+		}
+		err = CreateProfile(profileController, newProfile)
+		if err != nil {
+			DisplayError(err, CreateNewProfileCommandName)
+			return
+		}
+		fmt.Println("profile created successfully")
 	},
+}
+
+func getProfileName(cmd *cobra.Command, controller profile.Controller) (string, error) {
+	name, _ := cmd.Flags().GetString(FlagProfileCreateName)
+	if err := validateProfileName(name, controller); err != nil {
+		return "", err
+	}
+	return name, nil
 }
 
 //deleteProfilesCmd deletes profiles by names
@@ -93,6 +128,7 @@ var deleteProfilesCmd = &cobra.Command{
 			DisplayError(err, DeleteProfilesCommandName)
 			return
 		}
+		fmt.Println("profile deleted successfully")
 	},
 }
 
@@ -123,11 +159,29 @@ func init() {
 	profileCommand.AddCommand(createProfileCmd)
 	profileCommand.AddCommand(deleteProfilesCmd)
 	profileCommand.AddCommand(listProfileCmd)
+
+	//profile flags
+	profileCommand.Flags().BoolP(FlagProfileHelp, "h", false, "Help for "+ProfileCommandName)
+
+	//profile list flags
 	listProfileCmd.Flags().BoolP(FlagProfileVerbose, "l", false, "Shows information like name, endpoint, user")
-	listProfileCmd.Flags().BoolP("help", "h", false, "Help for "+ListProfilesCommandName)
-	createProfileCmd.Flags().BoolP("help", "h", false, "Help for "+CreateNewProfileCommandName)
-	deleteProfilesCmd.Flags().BoolP("help", "h", false, "Help for "+DeleteProfilesCommandName)
-	profileCommand.Flags().BoolP("help", "h", false, "Help for "+ProfileCommandName)
+	listProfileCmd.Flags().BoolP(FlagProfileHelp, "h", false, "Help for "+ListProfilesCommandName)
+
+	//profile create flags
+	createProfileCmd.Flags().StringP(FlagProfileCreateName, "n", "", "Create profile with this name")
+	_ = createProfileCmd.MarkFlagRequired(FlagProfileCreateName)
+	createProfileCmd.Flags().StringP(FlagProfileCreateEndpoint, "e", "", "Create profile with this endpoint or host")
+	_ = createProfileCmd.MarkFlagRequired(FlagProfileCreateEndpoint)
+	createProfileCmd.Flags().StringP(FlagProfileCreateAuthType, "a", "", "Authentication type; permitted values are disabled, "+
+		"basic and aws-iam.\nIf security is disabled, provide --auth-type='disabled'.\nIf security is configured to "+
+		"basic HTTP Authentication, provide --auth-type='basic'.\nIf security is configured to use AWS IAM ARN as user, "+
+		"provide --auth-type='aws-iam'. The rest of the options are asked from the tty based on this value")
+	_ = createProfileCmd.MarkFlagRequired(FlagProfileCreateAuthType)
+	createProfileCmd.Flags().BoolP(FlagProfileHelp, "h", false, "Help for "+CreateNewProfileCommandName)
+
+	//profile delete flags
+	deleteProfilesCmd.Flags().BoolP(FlagProfileHelp, "h", false, "Help for "+DeleteProfilesCommandName)
+
 	GetRoot().AddCommand(profileCommand)
 }
 
@@ -143,59 +197,39 @@ func getProfileController(cfgFlagValue string) (profile.Controller, error) {
 }
 
 // CreateProfile creates a new named profile
-func CreateProfile(profileController profile.Controller, getNewProfile func(map[string]entity.Profile) entity.Profile) error {
-	profiles, err := profileController.GetProfilesMap()
-	if err != nil {
-		return fmt.Errorf("failed to get profile names due to: %w", err)
-	}
-	newProfile := getNewProfile(profiles)
-	if err = profileController.CreateProfile(newProfile); err != nil {
+func CreateProfile(profileController profile.Controller, newProfile entity.Profile) error {
+	if err := profileController.CreateProfile(newProfile); err != nil {
 		return fmt.Errorf("failed to create profile %v due to: %w", newProfile, err)
 	}
 	return nil
 }
 
-// getNewProfile gets new profile information from user using command line
-func getNewProfile(profileMap map[string]entity.Profile) entity.Profile {
-	var name string
-	for {
-		fmt.Printf("Enter profile's name: ")
-		name = getUserInputAsText(checkInputIsNotEmpty)
-		if _, ok := profileMap[name]; !ok {
-			break
-		}
-		fmt.Println("profile", name, "already exists.")
+func validateProfileName(name string, controller profile.Controller) error {
+	profileMap, err := controller.GetProfilesMap()
+	if err != nil {
+		return err
 	}
-	fmt.Printf("Elasticsearch Endpoint: ")
-	endpoint := getUserInputAsText(checkInputIsNotEmpty)
-	fmt.Printf("Is security plugin enabled? Y/N ")
-	isSecured := getUserInputAsBoolean(checkInputIsNotEmpty)
-	var user, password string
-	if isSecured {
-		fmt.Printf("User Name: ")
-		user = getUserInputAsText(checkInputIsNotEmpty)
-		fmt.Printf("Password: ")
-		password = getUserInputAsMaskedText(checkInputIsNotEmpty)
+	if _, ok := profileMap[name]; !ok {
+		return nil
 	}
-	return entity.Profile{
-		Name:     name,
-		Endpoint: endpoint,
-		UserName: user,
-		Password: password,
-	}
+	return fmt.Errorf("profile %s already exists", name)
 }
 
-func getUserInputAsBoolean(isValid func(input string) bool) bool {
-	response := getUserInputAsText(isValid)
-	switch strings.ToLower(response) {
-	case "y", "yes":
-		return true
-	case "n", "no":
-		return false
-	default:
-		fmt.Printf("please type (y)es or (n)o: ")
-		return getUserInputAsBoolean(isValid)
+// getBasicAuthDetails gets new basic HTTP Auth profile information from user using command line
+func getBasicAuthDetails(newProfile *entity.Profile) {
+	fmt.Printf("User Name: ")
+	newProfile.UserName = getUserInputAsText(checkInputIsNotEmpty)
+	fmt.Printf("Password: ")
+	newProfile.Password = getUserInputAsMaskedText(checkInputIsNotEmpty)
+}
+
+// getAWSIAMAuthDetails gets new AWS IAM Auth profile information from user using command line
+func getAWSIAMAuthDetails(newProfile *entity.Profile) {
+	fmt.Printf("AWS profile name (Leave blank if you want to provide credentials using environment variables): ")
+	awsIAM := &entity.AWSIAM{
+		ProfileName: getUserInputAsText(nil),
 	}
+	newProfile.AWS = awsIAM
 }
 
 // getUserInputAsText get value from user as text
@@ -203,7 +237,7 @@ func getUserInputAsText(isValid func(string) bool) string {
 	var response string
 	//Ignore return value since validation is applied below
 	_, _ = fmt.Scanln(&response)
-	if !isValid(response) {
+	if isValid != nil && !isValid(response) {
 		return getUserInputAsText(isValid)
 	}
 	return strings.TrimSpace(response)

--- a/commands/profile.go
+++ b/commands/profile.go
@@ -102,7 +102,7 @@ var createProfileCmd = &cobra.Command{
 			DisplayError(err, CreateNewProfileCommandName)
 			return
 		}
-		fmt.Println("profile created successfully")
+		fmt.Println("Profile created successfully.")
 	},
 }
 
@@ -128,7 +128,7 @@ var deleteProfilesCmd = &cobra.Command{
 			DisplayError(err, DeleteProfilesCommandName)
 			return
 		}
-		fmt.Println("profile deleted successfully")
+		fmt.Println("Profile deleted successfully.")
 	},
 }
 
@@ -172,10 +172,9 @@ func init() {
 	_ = createProfileCmd.MarkFlagRequired(FlagProfileCreateName)
 	createProfileCmd.Flags().StringP(FlagProfileCreateEndpoint, "e", "", "Create profile with this endpoint or host")
 	_ = createProfileCmd.MarkFlagRequired(FlagProfileCreateEndpoint)
-	createProfileCmd.Flags().StringP(FlagProfileCreateAuthType, "a", "", "Authentication type; permitted values are disabled, "+
-		"basic and aws-iam.\nIf security is disabled, provide --auth-type='disabled'.\nIf security is configured to "+
-		"basic HTTP Authentication, provide --auth-type='basic'.\nIf security is configured to use AWS IAM ARN as user, "+
-		"provide --auth-type='aws-iam'. The rest of the options are asked from the tty based on this value")
+	createProfileCmd.Flags().StringP(FlagProfileCreateAuthType, "a", "", "Authentication type. Options are disabled, basic and aws-iam."+
+		"\nIf security is disabled, provide --auth-type='disabled'.\nIf security uses HTTP basic authentication, provide --auth-type='basic'.\n"+
+		"If security uses AWS IAM ARNs as users, provide --auth-type='aws-iam'.\nodfe-cli asks for additional information based on your choice of authentication type.")
 	_ = createProfileCmd.MarkFlagRequired(FlagProfileCreateAuthType)
 	createProfileCmd.Flags().BoolP(FlagProfileHelp, "h", false, "Help for "+CreateNewProfileCommandName)
 
@@ -217,7 +216,7 @@ func validateProfileName(name string, controller profile.Controller) error {
 
 // getBasicAuthDetails gets new basic HTTP Auth profile information from user using command line
 func getBasicAuthDetails(newProfile *entity.Profile) {
-	fmt.Printf("User Name: ")
+	fmt.Printf("Username: ")
 	newProfile.UserName = getUserInputAsText(checkInputIsNotEmpty)
 	fmt.Printf("Password: ")
 	newProfile.Password = getUserInputAsMaskedText(checkInputIsNotEmpty)
@@ -225,10 +224,11 @@ func getBasicAuthDetails(newProfile *entity.Profile) {
 
 // getAWSIAMAuthDetails gets new AWS IAM Auth profile information from user using command line
 func getAWSIAMAuthDetails(newProfile *entity.Profile) {
-	fmt.Printf("AWS profile name (Leave blank if you want to provide credentials using environment variables): ")
-	awsIAM := &entity.AWSIAM{
-		ProfileName: getUserInputAsText(nil),
-	}
+	fmt.Printf("AWS profile name (leave blank if you want to provide credentials using environment variables): ")
+	awsIAM := &entity.AWSIAM{}
+	awsIAM.ProfileName = getUserInputAsText(nil)
+	fmt.Printf("AWS service name where your cluster is deployed (for Amazon Elasticsearch Service, use 'es'. For EC2, use 'ec2'): ")
+	awsIAM.ServiceName = getUserInputAsText(checkInputIsNotEmpty)
 	newProfile.AWS = awsIAM
 }
 

--- a/controller/profile/profile_test.go
+++ b/controller/profile/profile_test.go
@@ -80,6 +80,70 @@ func TestControllerGetProfilesMap(t *testing.T) {
 	})
 }
 
+func TestControllerGetProfiles(t *testing.T) {
+
+	profiles := entity.Config{
+		Profiles: []entity.Profile{
+			{
+				Name:     "local",
+				Endpoint: "https://localhost:9200",
+				UserName: "", Password: "",
+			},
+			{
+				Name:     "default",
+				Endpoint: "https://127.0.0.1:9200",
+				UserName: "user", Password: "user123",
+			},
+			{
+				Name:     "default1",
+				Endpoint: "https://127.0.0.1:9200",
+				UserName: "user", Password: "user123",
+				AWS: &entity.AWSIAM{ProfileName: "iam"},
+			},
+			{
+				Name:     "default2",
+				Endpoint: "https://127.0.0.1:9200",
+				UserName: "user", Password: "user123",
+				AWS: &entity.AWSIAM{ProfileName: ""},
+			},
+		}}
+	t.Run("get profiles", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+		mockConfigCtrl := config.NewMockController(mockCtrl)
+		mockConfigCtrl.EXPECT().Read().Return(profiles, nil)
+		ctrl := New(mockConfigCtrl)
+		actual, err := ctrl.GetProfiles()
+		assert.NoError(t, err)
+		expectedProfiles := []entity.Profile{
+			{
+				Name:     "local",
+				Endpoint: "https://localhost:9200",
+				UserName: "", Password: "",
+			},
+			{
+				Name:     "default",
+				Endpoint: "https://127.0.0.1:9200",
+				UserName: "user", Password: "user123",
+			},
+			{
+				Name:     "default1",
+				Endpoint: "https://127.0.0.1:9200",
+				UserName: "user", Password: "user123",
+				AWS: &entity.AWSIAM{ProfileName: "iam"},
+			},
+			{
+				Name:     "default2",
+				Endpoint: "https://127.0.0.1:9200",
+				UserName: "user", Password: "user123",
+				AWS: &entity.AWSIAM{ProfileName: ""},
+			},
+		}
+
+		assert.EqualValues(t, expectedProfiles, actual)
+	})
+}
+
 func TestControllerGetProfileNames(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		mockCtrl := gomock.NewController(t)

--- a/entity/profile.go
+++ b/entity/profile.go
@@ -17,6 +17,7 @@ package entity
 
 type AWSIAM struct {
 	ProfileName string `yaml:"profile"`
+	ServiceName string `yaml:"service"`
 }
 type Profile struct {
 	Name     string  `yaml:"name"`

--- a/entity/profile.go
+++ b/entity/profile.go
@@ -15,9 +15,13 @@
 
 package entity
 
+type AWSIAM struct {
+	ProfileName string `yaml:"profile"`
+}
 type Profile struct {
-	Name     string `yaml:"name"`
-	Endpoint string `yaml:"endpoint"`
-	UserName string `yaml:"user"`
-	Password string `yaml:"password"`
+	Name     string  `yaml:"name"`
+	Endpoint string  `yaml:"endpoint"`
+	UserName string  `yaml:"user,omitempty"`
+	Password string  `yaml:"password,omitempty"`
+	AWS      *AWSIAM `yaml:"aws_iam,omitempty"`
 }

--- a/gateway/aws/signer/aws.go
+++ b/gateway/aws/signer/aws.go
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package signer
+
+import (
+	"bytes"
+	"errors"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	v4 "github.com/aws/aws-sdk-go/aws/signer/v4"
+	"github.com/hashicorp/go-retryablehttp"
+)
+
+const ElasticsearchService = "es"
+
+func GetV4Signer(credentials *credentials.Credentials) *v4.Signer {
+	return v4.NewSigner(credentials)
+}
+func sign(req *retryablehttp.Request, region *string, signer *v4.Signer) error {
+	bodyBytes, err := req.BodyBytes()
+	if err != nil {
+		return err
+	}
+	if region == nil || len(*region) == 0 {
+		return errors.New("aws region is not found. Either set 'AWS_REGION' or add this information during aws profile creation step")
+	}
+	// Sign the request
+	_, err = signer.Sign(req.Request, bytes.NewReader(bodyBytes), ElasticsearchService, *region, time.Now())
+	return err
+}
+
+//SignRequest signs the request using SigV4
+func SignRequest(req *retryablehttp.Request, profileName string, getSigner func(*credentials.Credentials) *v4.Signer) error {
+	awsSession, err := session.NewSessionWithOptions(session.Options{
+		Profile: profileName,
+	})
+
+	if err != nil {
+		return err
+	}
+	signer := getSigner(awsSession.Config.Credentials)
+	return sign(req, awsSession.Config.Region, signer)
+}

--- a/gateway/aws/signer/aws_test.go
+++ b/gateway/aws/signer/aws_test.go
@@ -17,6 +17,7 @@ package signer
 
 import (
 	"net/http"
+	"odfe-cli/entity"
 	"os"
 	"testing"
 
@@ -40,7 +41,10 @@ func TestV4Signer(t *testing.T) {
 		defer func() {
 			os.Setenv("AWS_REGION", region)
 		}()
-		err := SignRequest(req, "test1", func(c *credentials.Credentials) *v4.Signer {
+		err := SignRequest(req, entity.AWSIAM{
+			ProfileName: "test1",
+			ServiceName: "es",
+		}, func(c *credentials.Credentials) *v4.Signer {
 			return buildSigner()
 		})
 		assert.NoError(t, err)
@@ -55,7 +59,10 @@ func TestV4Signer(t *testing.T) {
 		defer func() {
 			os.Setenv("AWS_REGION", region)
 		}()
-		err := SignRequest(req, "test1", func(c *credentials.Credentials) *v4.Signer {
+		err := SignRequest(req, entity.AWSIAM{
+			ProfileName: "test1",
+			ServiceName: "es",
+		}, func(c *credentials.Credentials) *v4.Signer {
 			return buildSigner()
 		})
 		assert.EqualErrorf(

--- a/gateway/aws/signer/aws_test.go
+++ b/gateway/aws/signer/aws_test.go
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package signer
+
+import (
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	v4 "github.com/aws/aws-sdk-go/aws/signer/v4"
+	"github.com/hashicorp/go-retryablehttp"
+	"github.com/stretchr/testify/assert"
+)
+
+func buildSigner() *v4.Signer {
+	return &v4.Signer{
+		Credentials: credentials.NewStaticCredentials("AKID", "SECRET", "SESSION"),
+	}
+}
+
+func TestV4Signer(t *testing.T) {
+	t.Run("sign request success", func(t *testing.T) {
+		req, _ := retryablehttp.NewRequest(http.MethodGet, "https://localhost:9200", nil)
+		region := os.Getenv("AWS_REGION")
+		os.Setenv("AWS_REGION", "us-west-2")
+		defer func() {
+			os.Setenv("AWS_REGION", region)
+		}()
+		err := SignRequest(req, "test1", func(c *credentials.Credentials) *v4.Signer {
+			return buildSigner()
+		})
+		assert.NoError(t, err)
+		q := req.Header
+		assert.NotEmpty(t, q.Get("Authorization"))
+		assert.NotEmpty(t, q.Get("X-Amz-Date"))
+	})
+	t.Run("sign request failed due to no region found", func(t *testing.T) {
+		req, _ := retryablehttp.NewRequest(http.MethodGet, "https://localhost:9200", nil)
+		region := os.Getenv("AWS_REGION")
+		os.Setenv("AWS_REGION", "")
+		defer func() {
+			os.Setenv("AWS_REGION", region)
+		}()
+		err := SignRequest(req, "test1", func(c *credentials.Credentials) *v4.Signer {
+			return buildSigner()
+		})
+		assert.EqualErrorf(
+			t, err, "aws region is not found. Either set 'AWS_REGION' or add this information during aws profile creation step", "unexpected error")
+	})
+}

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -16,7 +16,6 @@
 package gateway
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -27,6 +26,7 @@ import (
 	"odfe-cli/client"
 	"odfe-cli/entity"
 	"odfe-cli/entity/es"
+	"odfe-cli/gateway/aws/signer"
 
 	"github.com/hashicorp/go-retryablehttp"
 )
@@ -78,7 +78,12 @@ func (g *HTTPGateway) isValidResponse(response *http.Response) error {
 
 //Execute calls request using http and check if status code is ok or not
 func (g *HTTPGateway) Execute(req *retryablehttp.Request) ([]byte, error) {
-
+	if g.Profile.AWS != nil {
+		//sign request
+		if err := signer.SignRequest(req, g.Profile.AWS.ProfileName, signer.GetV4Signer); err != nil {
+			return nil, err
+		}
+	}
 	response, err := g.Client.HTTPClient.Do(req)
 	if err != nil {
 		return nil, err
@@ -124,7 +129,7 @@ func (g *HTTPGateway) BuildRequest(ctx context.Context, method string, payload i
 
 //BuildCurlRequest builds request based on method and add payload (in byte)
 func (g *HTTPGateway) BuildCurlRequest(ctx context.Context, method string, payload []byte, url string, headers map[string]string) (*retryablehttp.Request, error) {
-	r, err := retryablehttp.NewRequest(method, url, bytes.NewBuffer(payload))
+	r, err := retryablehttp.NewRequest(method, url, payload)
 	if err != nil {
 		return nil, err
 	}
@@ -143,13 +148,7 @@ func (g *HTTPGateway) BuildCurlRequest(ctx context.Context, method string, paylo
 
 //GetValidEndpoint get url based on user config
 func GetValidEndpoint(profile *entity.Profile) (*url.URL, error) {
-	if len(profile.Endpoint) == 0 {
-		return &url.URL{
-			Scheme: "https",
-			Host:   "localhost:9200",
-		}, nil
-	}
-	u, err := url.Parse(profile.Endpoint)
+	u, err := url.ParseRequestURI(profile.Endpoint)
 	if err != nil {
 		return nil, fmt.Errorf("invalid endpoint: %v due to %v", profile.Endpoint, err)
 	}

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -80,7 +80,7 @@ func (g *HTTPGateway) isValidResponse(response *http.Response) error {
 func (g *HTTPGateway) Execute(req *retryablehttp.Request) ([]byte, error) {
 	if g.Profile.AWS != nil {
 		//sign request
-		if err := signer.SignRequest(req, g.Profile.AWS.ProfileName, signer.GetV4Signer); err != nil {
+		if err := signer.SignRequest(req, *g.Profile.AWS, signer.GetV4Signer); err != nil {
 			return nil, err
 		}
 	}

--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package gateway
+
+import (
+	"odfe-cli/entity"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetValidEndpoint(t *testing.T) {
+	t.Run("valid endpoint", func(t *testing.T) {
+
+		profile := entity.Profile{
+			Name:     "test1",
+			Endpoint: "https://localhost:9200",
+			UserName: "foo",
+			Password: "bar",
+		}
+		url, err := GetValidEndpoint(&profile)
+		assert.NoError(t, err)
+		assert.EqualValues(t, "https://localhost:9200", url.String())
+	})
+	t.Run("empty endpoint", func(t *testing.T) {
+		profile := entity.Profile{
+			Name:     "test1",
+			Endpoint: "",
+			UserName: "foo",
+			Password: "bar",
+		}
+		_, err := GetValidEndpoint(&profile)
+		assert.EqualErrorf(t, err, "invalid endpoint:  due to parse \"\": empty url", "failed to get expected error")
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module odfe-cli
 go 1.14
 
 require (
+	github.com/aws/aws-sdk-go v1.37.25
 	github.com/cheggaaa/pb/v3 v3.0.5
 	github.com/golang/mock v1.4.4
 	github.com/hashicorp/go-retryablehttp v0.6.7

--- a/go.sum
+++ b/go.sum
@@ -21,6 +21,8 @@ github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRF
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
+github.com/aws/aws-sdk-go v1.37.25 h1:q1C/ILIVusSmqgWG4tFU0uVt3Zm+1I3L2BmNCd2Ug4Q=
+github.com/aws/aws-sdk-go v1.37.25/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
@@ -103,6 +105,10 @@ github.com/hashicorp/memberlist v0.1.3/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2p
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
+github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
+github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
+github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
+github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
@@ -145,6 +151,7 @@ github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FI
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
@@ -200,6 +207,7 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5 h1:58fnuSXlxZmFdJyvtTFVmVhcMLU6v5fEb/ok4wyqtNU=
 golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=
@@ -232,6 +240,8 @@ golang.org/x/net v0.0.0-20190501004415-9ce7a6920f09/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190503192946-f4e77d36d62c/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190603091049-60506f45cf65/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20201110031124-69a78807bb2b h1:uwuIcX0g4Yl1NC5XAz37xsr2lTtcqevgzYNVt49waME=
+golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -257,6 +267,7 @@ golang.org/x/sys v0.0.0-20190606165138-5da285871e9c/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42 h1:vEOn+mP2zCOVzKckCZy6YsCtDblrpj/w7B9nxGNELpg=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68 h1:nxC68pudNYkKU6jWhgrqdreuFiOQWj1Fs7T3VrH4Pjw=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/term v0.0.0-20201210144234-2321bbc49cbf h1:MZ2shdL+ZM/XzY3ZGOnh4Nlpnxz5GSOhOmtHo3iPU6M=
@@ -264,6 +275,8 @@ golang.org/x/term v0.0.0-20201210144234-2321bbc49cbf/go.mod h1:bj7SfCRtBDWHUb9sn
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
+golang.org/x/text v0.3.3 h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=
+golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180221164845-07fd8470d635/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -49,6 +49,11 @@ func StringToStringPtr(r string) *string {
 	return &r
 }
 
+// BoolToBoolPtr maps a bool to a *bool.
+func BoolToBoolPtr(r bool) *bool {
+	return &r
+}
+
 // StringPtrToString maps a *string to a string,
 // defaulting to "" if the pointer is nil.
 func StringPtrToString(r *string) string {


### PR DESCRIPTION
In order to support IAM Authentication, revamped existing
profile creation. Now user can provide type of auth as flag to
profile creation command.

For IAM, if odfe-cli profile contains AWS profile name, it will be used.
if left bank, it is expected to get credetials from Environment variables.

once it is identified as AWS IAM Authentications, cli will sign the request
before execute.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
