### PR TITLE
Allow aws sdk to read shared config file

### DIFF
--- a/gateway/aws/signer/aws.go
+++ b/gateway/aws/signer/aws.go
@@ -46,7 +46,8 @@ func sign(req *retryablehttp.Request, region *string, serviceName string, signer
 //SignRequest signs the request using SigV4
 func SignRequest(req *retryablehttp.Request, awsProfile entity.AWSIAM, getSigner func(*credentials.Credentials) *v4.Signer) error {
 	awsSession, err := session.NewSessionWithOptions(session.Options{
-		Profile: awsProfile.ProfileName,
+		Profile:           awsProfile.ProfileName,
+		SharedConfigState: session.SharedConfigEnable,
 	})
 
 	if err != nil {


### PR DESCRIPTION
By default, aws region is not read by sdk. Enable shared config state,
will let sdk select profile's region or default region before
expecting from environment variable.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
