### PR TITLE
Add max retry parameter to profile

### DIFF
--- a/commands/profile.go
+++ b/commands/profile.go
@@ -42,6 +42,7 @@ const (
 	FlagProfileCreateName       = "name"
 	FlagProfileCreateEndpoint   = "endpoint"
 	FlagProfileCreateAuthType   = "auth-type"
+	FlagProfileMaxRetry         = "max-retry"
 	FlagProfileHelp             = "help"
 )
 
@@ -82,9 +83,11 @@ var createProfileCmd = &cobra.Command{
 			return
 		}
 		endpoint, _ := cmd.Flags().GetString(FlagProfileCreateEndpoint)
+		maxAttempt, _ := cmd.Flags().GetInt(FlagProfileMaxRetry)
 		newProfile := entity.Profile{
 			Name:     name,
 			Endpoint: endpoint,
+			MaxRetry: &maxAttempt,
 		}
 		switch authType, _ := cmd.Flags().GetString(FlagProfileCreateAuthType); authType {
 		case "disabled":
@@ -176,6 +179,8 @@ func init() {
 		"\nIf security is disabled, provide --auth-type='disabled'.\nIf security uses HTTP basic authentication, provide --auth-type='basic'.\n"+
 		"If security uses AWS IAM ARNs as users, provide --auth-type='aws-iam'.\nodfe-cli asks for additional information based on your choice of authentication type.")
 	_ = createProfileCmd.MarkFlagRequired(FlagProfileCreateAuthType)
+	createProfileCmd.Flags().IntP(FlagProfileMaxRetry, "m", 3, "Specifies a value of maximum retry attempts the odfe-cli retry handler can perform.\n"+
+		"You can override this value by using the ODFE_MAX_RETRY environment variable.")
 	createProfileCmd.Flags().BoolP(FlagProfileHelp, "h", false, "Help for "+CreateNewProfileCommandName)
 
 	//profile delete flags

--- a/commands/profile_test.go
+++ b/commands/profile_test.go
@@ -115,16 +115,19 @@ func TestCreateProfile(t *testing.T) {
 			"--" + FlagProfileCreateAuthType, "disabled",
 			"--" + FlagProfileCreateEndpoint, testProfileEndpoint,
 			"--" + FlagProfileCreateName, testProfileName,
+			"--" + FlagProfileMaxRetry, "2",
 		})
 		_, err = root.ExecuteC()
 		assert.NoError(t, err)
 		contents, _ := ioutil.ReadFile(f.Name())
 		var actual entity.Config
 		assert.NoError(t, yaml.Unmarshal(contents, &actual))
+		retryVal := 2
 		assert.EqualValues(t, []entity.Profile{
 			{
 				Name:     testProfileName,
 				Endpoint: testProfileEndpoint,
+				MaxRetry: &retryVal,
 			},
 		}, actual.Profiles)
 

--- a/entity/profile.go
+++ b/entity/profile.go
@@ -25,4 +25,5 @@ type Profile struct {
 	UserName string  `yaml:"user,omitempty"`
 	Password string  `yaml:"password,omitempty"`
 	AWS      *AWSIAM `yaml:"aws_iam,omitempty"`
+	MaxRetry *int    `yaml:"max_retry"`
 }

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -27,6 +27,8 @@ import (
 	"odfe-cli/entity"
 	"odfe-cli/entity/es"
 	"odfe-cli/gateway/aws/signer"
+	"os"
+	"strconv"
 
 	"github.com/hashicorp/go-retryablehttp"
 )
@@ -46,6 +48,16 @@ func GetDefaultHeaders() map[string]string {
 
 //NewHTTPGateway creates new HTTPGateway instance
 func NewHTTPGateway(c *client.Client, p *entity.Profile) *HTTPGateway {
+	// set max retry if provided by command
+	if p.MaxRetry != nil {
+		c.HTTPClient.RetryMax = *p.MaxRetry
+	}
+	if val, ok := os.LookupEnv("ODFE_MAX_RETRY"); ok {
+		//ignore error from non positive number
+		if attempt, err := strconv.Atoi(val); err == nil {
+			c.HTTPClient.RetryMax = attempt
+		}
+	}
 	return &HTTPGateway{
 		Client:  c,
 		Profile: p,


### PR DESCRIPTION
At present, default retry is 4 ( 5 total attempts) . This value is
controlled by dependent library. Hence, introduce an option to
allow user to set as profile settings.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
