### PR TITLE
Configure connection timeout

### DIFF
--- a/client/http.go
+++ b/client/http.go
@@ -18,9 +18,12 @@ package client
 import (
 	"crypto/tls"
 	"net/http"
+	"time"
 
 	"github.com/hashicorp/go-retryablehttp"
 )
+
+const defaultTimeout = 10
 
 //Client is an Abstraction for actual client
 type Client struct {
@@ -32,6 +35,7 @@ func NewDefaultClient(tripper http.RoundTripper) (*Client, error) {
 
 	client := retryablehttp.NewClient()
 	client.HTTPClient.Transport = tripper
+	client.HTTPClient.Timeout = defaultTimeout * time.Second
 	client.Logger = nil
 	return &Client{
 		HTTPClient: client,

--- a/commands/profile.go
+++ b/commands/profile.go
@@ -43,6 +43,7 @@ const (
 	FlagProfileCreateEndpoint   = "endpoint"
 	FlagProfileCreateAuthType   = "auth-type"
 	FlagProfileMaxRetry         = "max-retry"
+	FlagProfileTimeout          = "timeout"
 	FlagProfileHelp             = "help"
 )
 
@@ -84,10 +85,12 @@ var createProfileCmd = &cobra.Command{
 		}
 		endpoint, _ := cmd.Flags().GetString(FlagProfileCreateEndpoint)
 		maxAttempt, _ := cmd.Flags().GetInt(FlagProfileMaxRetry)
+		timeout, _ := cmd.Flags().GetInt64(FlagProfileTimeout)
 		newProfile := entity.Profile{
 			Name:     name,
 			Endpoint: endpoint,
 			MaxRetry: &maxAttempt,
+			Timeout:  &timeout,
 		}
 		switch authType, _ := cmd.Flags().GetString(FlagProfileCreateAuthType); authType {
 		case "disabled":
@@ -179,8 +182,10 @@ func init() {
 		"\nIf security is disabled, provide --auth-type='disabled'.\nIf security uses HTTP basic authentication, provide --auth-type='basic'.\n"+
 		"If security uses AWS IAM ARNs as users, provide --auth-type='aws-iam'.\nodfe-cli asks for additional information based on your choice of authentication type.")
 	_ = createProfileCmd.MarkFlagRequired(FlagProfileCreateAuthType)
-	createProfileCmd.Flags().IntP(FlagProfileMaxRetry, "m", 3, "Specifies a value of maximum retry attempts the odfe-cli retry handler can perform.\n"+
+	createProfileCmd.Flags().IntP(FlagProfileMaxRetry, "m", 3, "Maximum retry attempts allowed if transient problems occur.\n"+
 		"You can override this value by using the ODFE_MAX_RETRY environment variable.")
+	createProfileCmd.Flags().Int64P(FlagProfileTimeout, "t", 10, "Maximum time allowed for connection in seconds.\n"+
+		"You can override this value by using the ODFE_TIMEOUT environment variable.")
 	createProfileCmd.Flags().BoolP(FlagProfileHelp, "h", false, "Help for "+CreateNewProfileCommandName)
 
 	//profile delete flags

--- a/commands/profile_test.go
+++ b/commands/profile_test.go
@@ -116,6 +116,7 @@ func TestCreateProfile(t *testing.T) {
 			"--" + FlagProfileCreateEndpoint, testProfileEndpoint,
 			"--" + FlagProfileCreateName, testProfileName,
 			"--" + FlagProfileMaxRetry, "2",
+			"--" + FlagProfileTimeout, "10",
 		})
 		_, err = root.ExecuteC()
 		assert.NoError(t, err)
@@ -123,11 +124,13 @@ func TestCreateProfile(t *testing.T) {
 		var actual entity.Config
 		assert.NoError(t, yaml.Unmarshal(contents, &actual))
 		retryVal := 2
+		timeout := int64(10)
 		assert.EqualValues(t, []entity.Profile{
 			{
 				Name:     testProfileName,
 				Endpoint: testProfileEndpoint,
 				MaxRetry: &retryVal,
+				Timeout:  &timeout,
 			},
 		}, actual.Profiles)
 

--- a/docs/guide/usage.md
+++ b/docs/guide/usage.md
@@ -201,3 +201,9 @@ If defined, `ODFE_MAX_RETRY` overrides the value for the individual profiles set
 Specifies the name of the ofe-cli profile to use.
 If defined, this environment variable overrides the behavior of using the profile named `[default]` in the configuration file.
 You can override this environment variable by using the `--profile` command line parameter.
+
+`ODFE_TIMEOUT`  
+Specifies maximum time  in  seconds  that you allow the connection to the server to take.
+If defined, `ODFE_TIMEOUT` overrides the value for the individual profiles setting `timeout`.
+This only limits  the  connection  phase, once timeout happens, client will only exit, it doesn't terminate the
+request that already reached the server.

--- a/entity/profile.go
+++ b/entity/profile.go
@@ -25,5 +25,6 @@ type Profile struct {
 	UserName string  `yaml:"user,omitempty"`
 	Password string  `yaml:"password,omitempty"`
 	AWS      *AWSIAM `yaml:"aws_iam,omitempty"`
-	MaxRetry *int    `yaml:"max_retry"`
+	MaxRetry *int    `yaml:"max_retry,omitempty"`
+	Timeout  *int64  `yaml:"timeout,omitempty"`
 }


### PR DESCRIPTION
Allow users to configure timeout either while creating profile / environment variables
Default is 10 seconds.

*Issue #, if available:*
#62 



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
